### PR TITLE
Fix MCP Server link in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,7 +12,7 @@
 
 ### 🧠 AI & LLM Integrations
 
-- [MCP Server →](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol)
+- [MCP Server →](https://www.chargebee.com/docs/billing/2.0/ai-in-chargebee/chargebee-mcp)
 - [API Explorer →](https://api-explorer.chargebee.com?utm_source=github_profile)
 
 ### 👨‍💻 Your Stack, Our SDKs


### PR DESCRIPTION
Updated MCP Server link to point to the Chargebee documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the README’s MCP Server link to point to Chargebee’s official `chargebee-mcp` documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->