### PR TITLE
Add Cloud Agent dev environment for profile README preview

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Chargebee GitHub profile",
+  "install": "pip3 install --user --break-system-packages grip",
+  "terminals": [
+    {
+      "name": "readme-preview",
+      "command": "python3 -m grip profile/README.md 0.0.0.0:6419 --context=chargebee/.github",
+      "description": "Live GitHub-accurate preview of profile/README.md, served at http://localhost:6419"
+    }
+  ],
+  "ports": [
+    {
+      "name": "README preview",
+      "port": 6419
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repository is Chargebee's GitHub organization **profile** repo. Its only tracked content is `profile/README.md` (plus a root `README.md` symlink). There is no application code, package manager, build system, tests, or services.

The meaningful "development experience" here is editing the profile Markdown and previewing it exactly as GitHub renders it. This PR adds a repository-managed Cloud Agent environment (`.cursor/environment.json`) that:

- `install`: installs [`grip`](https://github.com/joeyespo/grip) (GitHub Readme Instant Preview) — idempotent, no repo dependencies.
- `terminals`: runs a live preview server that renders `profile/README.md` with GitHub-accurate styling at `http://localhost:6419`.
- `ports`: exposes port `6419`.

Because the config lives in `.cursor/environment.json`, it is the highest-precedence environment source and follows this branch/PR — no dashboard Save is required. Merging this PR makes it effective for future agents on `main`.

## Validation

| Check | Result |
| --- | --- |
| `grip` preview server (`profile/README.md` → `localhost:6419`) | HTTP 200, renders `markdown-body`, tagline, all sections, links |
| Browser render of the profile page | Verified via screen recording |
| `install` idempotence | Passed twice |
| Clean install in a draft environment build | `bld-20260813-361101fa-68ac-483c-a9ab-1bb5520d0bc3` SUCCEEDED, `grip-4.6.2` installed, exit 0 |
| Fresh Cloud Agent booted from that build on this branch | PASS — grip present, `terminals` server serves rendered README (HTTP 200) |

## Notes

`grip` renders via GitHub's Markdown API (`api.github.com`); unauthenticated use is subject to a 60 requests/hour rate limit, which is ample for local preview.

[readme_preview_end_to_end.mp4](https://cursor.com/agents/bc-4fa96ba0-60e1-4d3b-8d55-c9867167d8d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freadme_preview_end_to_end.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fa96ba0-60e1-4d3b-8d55-c9867167d8d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fa96ba0-60e1-4d3b-8d55-c9867167d8d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a Cursor development environment that installs `grip`, previews `profile/README.md` at `http://localhost:6419`, and exposes port `6419`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->